### PR TITLE
Allow better text representation of parsed document

### DIFF
--- a/lib/wraptext/parser.rb
+++ b/lib/wraptext/parser.rb
@@ -41,6 +41,10 @@ module Wraptext
       @doc_out ||= @root.xpath("/html/body").first
     end
 
+    def to_text
+      @doc_out ||= @doc.xpath("/html/body").text.strip
+    end
+
     private
 
     def replace_single_breaks


### PR DESCRIPTION
Grabbing text using the existing `to_doc` method destroyed relevant spacing between non block-level elements.

This PR adds `to_text` expose the parsed/cleaned up text of the original document.
